### PR TITLE
[#4] Create base form components - Deploy Storybook

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -32,3 +32,34 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
+
+  deploy-storybook-preview:
+    name: Build and Deploy Storybook Preview on Netlify
+    runs-on: ubuntu-18.04
+    environment: staging
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run storybook:build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: './storybook-static'
+          alias: storybook-${{ github.event.number }}
+          deploy-message: '[Storybook] #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   deploy-preview:
     name: Build and Deploy Preview on Netlify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: staging
     outputs:
       deploy-url: ${{ steps.deploy.outputs.deploy-url }}
@@ -40,7 +40,7 @@ jobs:
 
   deploy-storybook-preview:
     name: Build and Deploy Storybook Preview on Netlify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: staging
     outputs:
       deploy-url: ${{ steps.deploy.outputs.deploy-url }}
@@ -75,7 +75,7 @@ jobs:
 
   create-deploy-comment:
     name: Create deploy comment on the PR
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [deploy-preview, deploy-storybook-preview]
     steps:
       - name: Find Comment

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -16,7 +16,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci
@@ -51,7 +51,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -7,6 +7,8 @@ jobs:
     name: Build and Deploy Preview on Netlify
     runs-on: ubuntu-18.04
     environment: staging
+    outputs:
+      deploy-url: ${{ steps.deploy.outputs.deploy-url }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -24,10 +26,13 @@ jobs:
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2
+        id: deploy
         with:
           publish-dir: './build'
+          alias: ${{ github.event.number }}
           deploy-message: '#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-pull-request-comment: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -37,6 +42,8 @@ jobs:
     name: Build and Deploy Storybook Preview on Netlify
     runs-on: ubuntu-18.04
     environment: staging
+    outputs:
+      deploy-url: ${{ steps.deploy.outputs.deploy-url }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -54,12 +61,38 @@ jobs:
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2
+        id: deploy
         with:
           publish-dir: './storybook-static'
           alias: storybook-${{ github.event.number }}
           deploy-message: '[Storybook] #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-pull-request-comment: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
+
+  create-deploy-comment:
+    name: Create deploy comment on the PR
+    runs-on: ubuntu-18.04
+    needs: [deploy-preview, deploy-storybook-preview]
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Preview deployed successfully
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            Preview deployed successfully:
+            - 👾 Site: ${{needs.deploy-preview.outputs.deploy-url}}
+            - 📕 Storybook: ${{needs.deploy-storybook-preview.outputs.deploy-url}}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     name: Build and Deploy to Production
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: production
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -21,7 +21,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -21,7 +21,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci
@@ -52,7 +52,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install modules
         run: npm ci

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     name: Build and Deploy to Staging
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: staging
     steps:
       - name: Cancel Previous Runs
@@ -43,7 +43,7 @@ jobs:
 
   deploy-storybook:
     name: Build and Deploy Storybook to Staging
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: staging
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -40,3 +40,34 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
+
+  deploy-storybook:
+    name: Build and Deploy Storybook to Staging
+    runs-on: ubuntu-18.04
+    environment: staging
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run storybook:build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: './storybook-static'
+          alias: storybook
+          deploy-message: 'Deploy Storybook from GitHub Actions: ${{ github.event.inputs.deploy-msg }}'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
         uses: actions/setup-node@v3
@@ -37,7 +37,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
         uses: actions/setup-node@v3
@@ -67,7 +67,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
         uses: actions/setup-node@v3
@@ -101,7 +101,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node and restore cached dependencies
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 A Nimble Internal Certification project to learn and have fun with React 🚀
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/410ea63b-c0fc-4184-a49f-0aa4018d1181/deploy-status)](https://app.netlify.com/sites/react-nimble-survey-staging/deploys) Staging: https://react-nimble-survey-staging.netlify.app/
+- 📕 Storybook: https://storybook--react-nimble-survey-staging.netlify.app
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/dc81fd86-3a45-4646-93cc-b1a3870433a0/deploy-status)](https://app.netlify.com/sites/react-nimble-survey/deploys) Production: https://react-nimble-survey.netlify.app/
+- 🕵️‍♀️ Staging [![Netlify Status](https://api.netlify.com/api/v1/badges/410ea63b-c0fc-4184-a49f-0aa4018d1181/deploy-status)](https://app.netlify.com/sites/react-nimble-survey-staging/deploys): https://react-nimble-survey-staging.netlify.app
+
+- ⚡️ Production [![Netlify Status](https://api.netlify.com/api/v1/badges/dc81fd86-3a45-4646-93cc-b1a3870433a0/deploy-status)](https://app.netlify.com/sites/react-nimble-survey/deploys): https://react-nimble-survey.netlify.app
 
 *📝 This project was bootstrapped with [Nimble React template](https://github.com/nimblehq/react-templates).*
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -13,7 +13,7 @@ schedule(
     entrySortMethod: 'least-coverage', // || 'alphabetically' || 'most-coverage' || 'largest-file-size' ||'smallest-file-size' || 'uncovered-lines'
 
     // Add a maximum number of entries to display
-    numberOfEntries: 15,
+    numberOfEntries: 6,
 
     // The location of the istanbul coverage file.
     // coveragePath: './.nyc_output/out.json', // The merged JSON coverage data

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cypress:e2e": "cypress run --quiet",
     "cypress:open": "cypress open",
     "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public"
+    "storybook:build": "build-storybook -s public"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",
       "!src/**/*.d.ts",
-      "!src/**/*.cy.{js,jsx,ts,tsx}"
+      "!src/**/*.cy.{js,jsx,ts,tsx}",
+      "!src/**/*.stories.{js,jsx,ts,tsx}"
     ],
     "coverageReporters": [
       "json"


### PR DESCRIPTION
https://github.com/rosle/react-nimble-survey/issues/4

## What happened 👀

- Deploy the Storybook to Netlify + adjust notifications
- Reduce the coverage report shown on the PR from 15 -> 6
- Exclude Storybook files from the coverage

## Insight 📝

Right now Storybook will be deployed on `Staging` only
- Storybook Preview for each working PR - for this PR -> https://storybook-23--react-nimble-survey-staging.netlify.app/
- Storybook Staging when a PR is merged to develop - https://storybook--react-nimble-survey-staging.netlify.app/

### Custom Deploy Comment

As of right now, we're having 2 deployments done in a PR. We should display the deploy URL of both React site and Storybook. So I did small customization on the deploy preview workflow:

![Screen Shot 2565-08-17 at 16 32 56](https://user-images.githubusercontent.com/6965195/185085776-da79fc63-bcc4-4712-8122-fa6d07cb3178.png)

### Update Virtual Environment

From ubuntu `18.04` to `latest` to fix the warning:

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

## Proof Of Work 📹

You should now be able to access Storybook preview: https://storybook-23--react-nimble-survey-staging.netlify.app
For staging, we will need to wait for this to merge. 👍 
