### PR TITLE
[#31][Backend] As a user, I am logged out after my access token token is expired

### DIFF
--- a/cypress.d.ts
+++ b/cypress.d.ts
@@ -9,7 +9,7 @@ declare global {
       mount: typeof mount;
       mountWithRouter: typeof mount;
       login(): typeof Chainable;
-      login(user: User, tokens: Tokens): typeof Chainable;
+      login(user: Nullable<User>, tokens: Nullable<Tokens>): typeof Chainable;
     }
   }
 }

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,8 +1,27 @@
+import { buildTokens } from 'tests/factories/token';
+
 describe('Home', () => {
   it('visits the app', () => {
     cy.login();
     cy.visit('/');
 
     cy.findByText('This is the home page content').should('be.visible');
+  });
+
+  context('given the token has already expired', () => {
+    it('redirects to the Login page', () => {
+      const tokens = buildTokens();
+
+      cy.intercept('GET', '/api/v1/me', { statusCode: 401, fixture: 'invalid_token_error' });
+
+      // On the first render of the page, there is NO user.
+      // The API will try fetching the user profile.
+      cy.login(null, tokens);
+      cy.visit('/');
+
+      cy.location().should((location) => {
+        expect(location.pathname).to.eq('/sign_in');
+      });
+    });
   });
 });

--- a/cypress/fixtures/invalid_token_error.json
+++ b/cypress/fixtures/invalid_token_error.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "detail": "The access token is invalid",
+      "code": "invalid_token"
+    }
+  ]
+}

--- a/cypress/support/commands/login.ts
+++ b/cypress/support/commands/login.ts
@@ -15,7 +15,7 @@ const mockUser: User = {
   avatarUrl: 'https://secure.gravatar.com/avatar/252876a66bc74a8d0a8ec1ebb3dd991c',
 };
 
-const login = (user: User = mockUser, tokens: Tokens = mockTokens) => {
+const login = (user: Nullable<User> = mockUser, tokens: Nullable<Tokens> = mockTokens) => {
   localStorage.setItem('user', JSON.stringify(user));
   localStorage.setItem('tokens', JSON.stringify(tokens));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@cypress/code-coverage": "3.10.0",
         "@cypress/instrument-cra": "1.4.0",
         "@cypress/webpack-dev-server": "2.0.0",
+        "@faker-js/faker": "7.5.0",
         "@nimblehq/eslint-config-nimble-react": "1.1.0",
         "@nimblehq/stylelint-config-nimble": "1.0.2",
         "@pollyjs/adapter-node-http": "6.0.5",
@@ -3041,6 +3042,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.5.0.tgz",
+      "integrity": "sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -39510,6 +39521,12 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "@faker-js/faker": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.5.0.tgz",
+      "integrity": "sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==",
+      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@cypress/code-coverage": "3.10.0",
     "@cypress/instrument-cra": "1.4.0",
     "@cypress/webpack-dev-server": "2.0.0",
+    "@faker-js/faker": "7.5.0",
     "@nimblehq/eslint-config-nimble-react": "1.1.0",
     "@nimblehq/stylelint-config-nimble": "1.0.2",
     "@pollyjs/adapter-node-http": "6.0.5",

--- a/src/components/Layout/Default/index.cy.tsx
+++ b/src/components/Layout/Default/index.cy.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LocalStorageKey } from 'hooks/useLocalStorage';
+import { LocalStorageKey } from 'lib/localStorage';
 
 import DefaultLayout, { defaultLayoutTestIds } from '.';
 

--- a/src/components/Layout/Default/index.test.tsx
+++ b/src/components/Layout/Default/index.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { LocalStorageKey } from 'hooks/useLocalStorage';
+import { LocalStorageKey } from 'lib/localStorage';
 import { mockUserLoggedIn } from 'tests/mockUserLoggedIn';
 import { renderWithRouter } from 'tests/renderWithRouter';
 import { setupPolly } from 'tests/setupPolly';

--- a/src/contexts/UserContext.test.tsx
+++ b/src/contexts/UserContext.test.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { getLocalStorageValue, LocalStorageKey } from 'hooks/useLocalStorage';
+import { getLocalStorageValue, LocalStorageKey } from 'lib/localStorage';
 import { mockUserLoggedIn } from 'tests/mockUserLoggedIn';
 import { TokenType } from 'types/tokens';
 

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import useLocalStorage, { LocalStorageKey } from 'hooks/useLocalStorage';
+import useLocalStorage from 'hooks/useLocalStorage';
+import { LocalStorageKey } from 'lib/localStorage';
 import { Tokens } from 'types/tokens';
 import { User } from 'types/user';
 

--- a/src/hooks/useLocalStorage.test.tsx
+++ b/src/hooks/useLocalStorage.test.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { chain } from 'lodash';
 
+import { LocalStorageKey, LocalStorageValue } from 'lib/localStorage';
 import { User } from 'types/user';
 
-import useLocalStorage, { LocalStorageKey, LocalStorageValue } from './useLocalStorage';
+import useLocalStorage from './useLocalStorage';
 
 const localStorageKey = LocalStorageKey.user;
 const localStorageValueListItemTestIds = 'local-storage-value-list-item';

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,33 +1,17 @@
 import React, { useState } from 'react';
 
-import { Tokens } from 'types/tokens';
-import { User } from 'types/user';
-
-export const enum LocalStorageKey {
-  tokens = 'tokens',
-  user = 'user',
-}
-
-export type LocalStorageValue<T> = T extends LocalStorageKey.tokens ? Nullable<Tokens> : Nullable<User>;
-
-export const getLocalStorageValue = <T extends LocalStorageKey>(key: T): LocalStorageValue<T> => {
-  const storedJsonValue = localStorage.getItem(key);
-
-  return storedJsonValue ? JSON.parse(storedJsonValue) : null;
-};
+import { LocalStorageKey, LocalStorageValue, getLocalStorageValue, setLocalStorageValue } from 'lib/localStorage';
 
 const useLocalStorage = <T extends LocalStorageKey>(
   key: T,
   defaultValue: LocalStorageValue<T> = null as LocalStorageValue<T>
 ): [LocalStorageValue<T>, React.Dispatch<LocalStorageValue<T>>] => {
   const [value, setStateValue] = useState(() => {
-    const initialValue = getLocalStorageValue(key);
-
-    return initialValue || defaultValue;
+    return getLocalStorageValue(key) || defaultValue;
   });
 
   const setValue = (newValue: LocalStorageValue<T>) => {
-    localStorage.setItem(key, JSON.stringify(newValue));
+    setLocalStorageValue(key, newValue);
     setStateValue(newValue);
   };
 

--- a/src/lib/interceptors/handleRequestError.test.ts
+++ b/src/lib/interceptors/handleRequestError.test.ts
@@ -1,0 +1,51 @@
+import { LocalStorageKey } from 'lib/localStorage';
+import routePath from 'routes/routePath';
+import { buildAxiosError, buildAxiosResponse } from 'tests/factories/axios';
+import { mockUserLoggedIn } from 'tests/mockUserLoggedIn';
+
+import handleRequestError from './handleRequestError';
+
+describe('handleRequestError', () => {
+  describe('given the `invalid_token` API error', () => {
+    mockUserLoggedIn();
+
+    it('logs the user out, redirects to the Login page and returns the rejected promise with the given error', async () => {
+      const axiosResponse = buildAxiosResponse({
+        status: 401,
+        data: {
+          errors: [
+            {
+              code: 'invalid_token',
+              detail: 'The access token is invalid',
+            },
+          ],
+        },
+      });
+
+      const axiosError = buildAxiosError({ response: axiosResponse });
+
+      await expect(handleRequestError(axiosError)).rejects.toBe(axiosError);
+
+      expect(localStorage.getItem(LocalStorageKey.tokens)).toBe(JSON.stringify(null));
+      expect(localStorage.getItem(LocalStorageKey.user)).toBe(JSON.stringify(null));
+
+      expect(window.location.href).toBe(routePath.login);
+    });
+  });
+
+  describe('given the other API errors', () => {
+    it('returns the rejected promise with the given error', async () => {
+      const axiosError = buildAxiosError();
+
+      await expect(handleRequestError(axiosError)).rejects.toBe(axiosError);
+    });
+  });
+
+  describe('given the other unexpected errors', () => {
+    it('returns the rejected promise with the given error', async () => {
+      const axiosError = buildAxiosError({ response: undefined });
+
+      await expect(handleRequestError(axiosError)).rejects.toBe(axiosError);
+    });
+  });
+});

--- a/src/lib/interceptors/handleRequestError.test.ts
+++ b/src/lib/interceptors/handleRequestError.test.ts
@@ -33,7 +33,7 @@ describe('handleRequestError', () => {
     });
   });
 
-  describe('given the other API errors', () => {
+  describe('given other API errors', () => {
     it('returns the rejected promise with the given error', async () => {
       const axiosError = buildAxiosError();
 
@@ -41,7 +41,7 @@ describe('handleRequestError', () => {
     });
   });
 
-  describe('given the other unexpected errors', () => {
+  describe('given other unexpected errors', () => {
     it('returns the rejected promise with the given error', async () => {
       const axiosError = buildAxiosError({ response: undefined });
 

--- a/src/lib/interceptors/handleRequestError.ts
+++ b/src/lib/interceptors/handleRequestError.ts
@@ -12,7 +12,6 @@ const handleRequestError = (error: unknown) => {
   const apiError = new ApiError(error.response);
 
   if (isInvalidTokenError(apiError)) {
-    console.info('API TOKEN EXPIRED');
     setLocalStorageValue(LocalStorageKey.tokens, null);
     setLocalStorageValue(LocalStorageKey.user, null);
 

--- a/src/lib/interceptors/handleRequestError.ts
+++ b/src/lib/interceptors/handleRequestError.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+import ApiError from 'lib/errors/ApiError';
+import { LocalStorageKey, setLocalStorageValue } from 'lib/localStorage';
+import routePath from 'routes/routePath';
+
+const handleRequestError = (error: unknown) => {
+  if (!axios.isAxiosError(error) || !error.response) {
+    return Promise.reject(error);
+  }
+
+  const apiError = new ApiError(error.response);
+
+  if (isInvalidTokenError(apiError)) {
+    console.info('API TOKEN EXPIRED');
+    setLocalStorageValue(LocalStorageKey.tokens, null);
+    setLocalStorageValue(LocalStorageKey.user, null);
+
+    window.location.href = routePath.login;
+  }
+
+  return Promise.reject(error);
+};
+
+const isInvalidTokenError = (apiError: ApiError) => {
+  return apiError.status === 401 && apiError.errors[0].code === 'invalid_token';
+};
+
+export default handleRequestError;

--- a/src/lib/locaStorage.test.ts
+++ b/src/lib/locaStorage.test.ts
@@ -1,0 +1,33 @@
+import { buildUser } from 'tests/factories/user';
+
+import { getLocalStorageValue, LocalStorageKey, setLocalStorageValue } from './localStorage';
+
+describe('getLocalStorageValue', () => {
+  describe('given there is a value in the local storage', () => {
+    it('parses JSON to object and returns the value', () => {
+      const localStorageKey = LocalStorageKey.user;
+      const user = buildUser();
+
+      localStorage.setItem(localStorageKey, JSON.stringify(user));
+
+      expect(getLocalStorageValue(localStorageKey)).toEqual(user);
+    });
+  });
+
+  describe('given there is NO value in the local storage', () => {
+    it('returns null', () => {
+      expect(getLocalStorageValue(LocalStorageKey.user)).toBeNull();
+    });
+  });
+});
+
+describe('setLocalStorageValue', () => {
+  it('sets the given value as a JSON to the local storage', () => {
+    const localStorageKey = LocalStorageKey.user;
+    const user = buildUser();
+
+    setLocalStorageValue(localStorageKey, user);
+
+    expect(localStorage.getItem(localStorageKey)).toBe(JSON.stringify(user));
+  });
+});

--- a/src/lib/locaStorage.test.ts
+++ b/src/lib/locaStorage.test.ts
@@ -10,13 +10,17 @@ describe('getLocalStorageValue', () => {
 
       localStorage.setItem(localStorageKey, JSON.stringify(user));
 
-      expect(getLocalStorageValue(localStorageKey)).toEqual(user);
+      const localStorageValue = getLocalStorageValue(localStorageKey);
+
+      expect(localStorageValue).toEqual(user);
     });
   });
 
   describe('given there is NO value in the local storage', () => {
     it('returns null', () => {
-      expect(getLocalStorageValue(LocalStorageKey.user)).toBeNull();
+      const localStorageValue = getLocalStorageValue(LocalStorageKey.user);
+
+      expect(localStorageValue).toBeNull();
     });
   });
 });

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,0 +1,21 @@
+import { Tokens } from 'types/tokens';
+import { User } from 'types/user';
+
+export const enum LocalStorageKey {
+  tokens = 'tokens',
+  user = 'user',
+}
+
+export type LocalStorageValue<T> = T extends LocalStorageKey.tokens ? Nullable<Tokens> : Nullable<User>;
+
+const getLocalStorageValue = <T extends LocalStorageKey>(key: T): LocalStorageValue<T> => {
+  const storedJsonValue = localStorage.getItem(key);
+
+  return storedJsonValue ? JSON.parse(storedJsonValue) : null;
+};
+
+const setLocalStorageValue = <T extends LocalStorageKey>(key: T, newValue: LocalStorageValue<T>): void => {
+  localStorage.setItem(key, JSON.stringify(newValue));
+};
+
+export { getLocalStorageValue, setLocalStorageValue };

--- a/src/lib/requestManager.test.ts
+++ b/src/lib/requestManager.test.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosError, AxiosResponse, AxiosTransformer } from 'axios';
+import axios, { AxiosTransformer } from 'axios';
 
+import { buildAxiosError, buildAxiosResponse } from 'tests/factories/axios';
 import { mockTokensLoggedIn } from 'tests/mockUserLoggedIn';
 
 import ApiError from './errors/ApiError';
@@ -60,11 +61,8 @@ describe('requestManager', () => {
 
   describe('given the API responds with error status', () => {
     it('throws an ApiError containing the response', async () => {
-      const axiosResponse: AxiosResponse = {
-        config: {},
+      const axiosResponse = buildAxiosResponse({
         status: 400,
-        statusText: '',
-        headers: { 'content-type': 'application/json' },
         data: {
           errors: [
             {
@@ -73,16 +71,9 @@ describe('requestManager', () => {
             },
           ],
         },
-      };
+      });
 
-      const axiosError: AxiosError = {
-        config: {},
-        name: 'Error',
-        message: 'Request failed with status code 400',
-        isAxiosError: true,
-        toJSON: jest.fn(),
-        response: axiosResponse,
-      };
+      const axiosError = buildAxiosError({ response: axiosResponse });
 
       const requestSpy = jest.spyOn(axios, 'request').mockImplementation(() => Promise.reject(axiosError));
       const isAxiosErrorSpy = jest.spyOn(axios, 'isAxiosError').mockReturnValueOnce(true);

--- a/src/lib/requestManager.ts
+++ b/src/lib/requestManager.ts
@@ -4,6 +4,7 @@ import { camelizeKeys, decamelizeKeys } from 'humps';
 import { getLocalStorageValue, LocalStorageKey } from 'lib/localStorage';
 
 import ApiError from './errors/ApiError';
+import handleRequestError from './interceptors/handleRequestError';
 
 export const defaultOptions: AxiosRequestConfig = {
   baseURL: process.env.REACT_APP_API_BASE_URL,
@@ -11,6 +12,11 @@ export const defaultOptions: AxiosRequestConfig = {
   transformRequest: [(data) => decamelizeKeys(data), ...(axios.defaults.transformRequest as AxiosTransformer[])],
   transformResponse: [...(axios.defaults.transformResponse as AxiosTransformer[]), (data) => camelizeKeys(data)],
 };
+
+axios.interceptors.response.use(
+  (config) => config,
+  (error) => handleRequestError(error)
+);
 
 /**
  * The main API access function that comes preconfigured with useful defaults.

--- a/src/lib/requestManager.ts
+++ b/src/lib/requestManager.ts
@@ -1,7 +1,7 @@
 import axios, { Method as HTTPMethod, AxiosRequestConfig, AxiosResponse, AxiosTransformer } from 'axios';
 import { camelizeKeys, decamelizeKeys } from 'humps';
 
-import { getLocalStorageValue, LocalStorageKey } from 'hooks/useLocalStorage';
+import { getLocalStorageValue, LocalStorageKey } from 'lib/localStorage';
 
 import ApiError from './errors/ApiError';
 

--- a/src/routes/ProtectedRoute/index.test.tsx
+++ b/src/routes/ProtectedRoute/index.test.tsx
@@ -94,10 +94,10 @@ describe('ProtectedRoute', () => {
           renderRoutes(PROTECTED_ROUTE.path);
 
           await waitFor(() => {
-            expect(localStorage.getItem(LocalStorageKey.tokens)).toBe(JSON.stringify(null));
+            expect(window.location.href).toBe(routePath.login);
           });
 
-          expect(window.location.href).toBe(routePath.login);
+          expect(localStorage.getItem(LocalStorageKey.tokens)).toBe(JSON.stringify(null));
 
           await polly.stop();
         });

--- a/src/routes/ProtectedRoute/index.test.tsx
+++ b/src/routes/ProtectedRoute/index.test.tsx
@@ -93,10 +93,10 @@ describe('ProtectedRoute', () => {
           renderRoutes(PROTECTED_ROUTE.path);
 
           await waitFor(() => {
-            expect(screen.queryByText(LOGIN_ROUTE.content)).toBeVisible();
+            expect(localStorage.getItem(LocalStorageKey.tokens)).toBe(JSON.stringify(null));
           });
 
-          expect(localStorage.getItem(LocalStorageKey.tokens)).toBe(JSON.stringify(null));
+          expect(window.location.href).toBe('/sign_in');
 
           await polly.stop();
         });

--- a/src/routes/ProtectedRoute/index.test.tsx
+++ b/src/routes/ProtectedRoute/index.test.tsx
@@ -5,6 +5,7 @@ import { screen, waitFor } from '@testing-library/react';
 
 import { LocalStorageKey } from 'lib/localStorage';
 import AuthRoute from 'routes/AuthRoute';
+import routePath from 'routes/routePath';
 import { mockTokensLoggedIn, mockUserLoggedIn } from 'tests/mockUserLoggedIn';
 import { renderWithMemoryRouter } from 'tests/renderWithRouter';
 import { setupPolly } from 'tests/setupPolly';
@@ -96,7 +97,7 @@ describe('ProtectedRoute', () => {
             expect(localStorage.getItem(LocalStorageKey.tokens)).toBe(JSON.stringify(null));
           });
 
-          expect(window.location.href).toBe('/sign_in');
+          expect(window.location.href).toBe(routePath.login);
 
           await polly.stop();
         });

--- a/src/routes/ProtectedRoute/index.test.tsx
+++ b/src/routes/ProtectedRoute/index.test.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 
 import { screen, waitFor } from '@testing-library/react';
 
-import { LocalStorageKey } from 'hooks/useLocalStorage';
+import { LocalStorageKey } from 'lib/localStorage';
 import AuthRoute from 'routes/AuthRoute';
 import { mockTokensLoggedIn, mockUserLoggedIn } from 'tests/mockUserLoggedIn';
 import { renderWithMemoryRouter } from 'tests/renderWithRouter';

--- a/src/routes/ProtectedRoute/index.tsx
+++ b/src/routes/ProtectedRoute/index.tsx
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import UserAdapter from 'adapters/User';
 import { UserContext } from 'contexts/UserContext';
-
-const LOGIN_PAGE_PATH = '/sign_in';
+import routePath from 'routes/routePath';
 
 type ProtectedRouteProps = {
   children: JSX.Element;
@@ -14,7 +13,7 @@ type ProtectedRouteProps = {
   Routes for pages that require authentication before accessing.
 */
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const { tokens, setTokens, setUser, user } = useContext(UserContext);
+  const { tokens, setUser, user } = useContext(UserContext);
   const navigate = useNavigate();
 
   const fetchUserProfile = useCallback(async () => {
@@ -23,14 +22,13 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
       const userResponse = response.data.attributes;
 
       setUser(userResponse);
-    } catch (error) {
-      setTokens(null);
-      navigate(LOGIN_PAGE_PATH);
+    } catch (_error) {
+      // 401 should be raised and handle by request interceptor
     }
-  }, [navigate, setTokens, setUser]);
+  }, [setUser]);
 
   useEffect(() => {
-    if (!tokens) return navigate(LOGIN_PAGE_PATH);
+    if (!tokens) return navigate(routePath.login);
     if (user) return;
 
     fetchUserProfile();

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,10 +6,11 @@ import LoginScreen from 'screens/Login';
 
 import AuthRoute from './AuthRoute';
 import ProtectedRoute from './ProtectedRoute';
+import routePath from './routePath';
 
 const authRoutes: RouteObject[] = [
   {
-    path: '/sign_in',
+    path: routePath.login,
     element: (
       <AuthRoute>
         <LoginScreen />
@@ -20,7 +21,7 @@ const authRoutes: RouteObject[] = [
 
 const protectedRoutes: RouteObject[] = [
   {
-    path: '/',
+    path: routePath.index,
     element: (
       <ProtectedRoute>
         <HomeScreen />

--- a/src/routes/routePath.ts
+++ b/src/routes/routePath.ts
@@ -1,0 +1,6 @@
+const routePath = {
+  index: '/',
+  login: '/sign_in',
+};
+
+export default routePath;

--- a/src/tests/factories/axios.ts
+++ b/src/tests/factories/axios.ts
@@ -1,0 +1,33 @@
+import { AxiosError, AxiosResponse } from 'axios';
+
+const buildAxiosResponse = (attrs?: Partial<AxiosResponse>): AxiosResponse => {
+  return {
+    config: {},
+    status: 500,
+    statusText: '',
+    headers: { 'content-type': 'application/json' },
+    data: {
+      errors: [
+        {
+          code: 'internal_server_error',
+          detail: 'Something went wrong, please try again.',
+        },
+      ],
+    },
+    ...attrs,
+  };
+};
+
+const buildAxiosError = (attrs?: Partial<AxiosError>): AxiosError => {
+  return {
+    config: {},
+    name: 'Error',
+    message: 'Request failed',
+    isAxiosError: true,
+    toJSON: jest.fn(),
+    response: buildAxiosResponse(),
+    ...attrs,
+  };
+};
+
+export { buildAxiosResponse, buildAxiosError };

--- a/src/tests/factories/token.ts
+++ b/src/tests/factories/token.ts
@@ -1,0 +1,14 @@
+import { Tokens, TokenType } from 'types/tokens';
+
+const buildTokens = (attrs?: Partial<Tokens>): Tokens => {
+  return {
+    tokenType: TokenType.Bearer,
+    accessToken: 'access_token_12345',
+    refreshToken: 'refresh_token_12345',
+    createdAt: 1661852403,
+    expiresIn: 7200,
+    ...attrs,
+  };
+};
+
+export { buildTokens };

--- a/src/tests/factories/user.ts
+++ b/src/tests/factories/user.ts
@@ -1,0 +1,14 @@
+import { faker } from '@faker-js/faker';
+
+import { User } from 'types/user';
+
+const buildUser = (attrs?: Partial<User>): User => {
+  return {
+    email: faker.internet.email(),
+    name: faker.name.fullName(),
+    avatarUrl: faker.internet.url(),
+    ...attrs,
+  };
+};
+
+export { buildUser };

--- a/src/tests/globals/index.ts
+++ b/src/tests/globals/index.ts
@@ -1,3 +1,5 @@
 import mockLocalStorage from './mockLocalStorage';
+import mockLocation from './mockLocation';
 
 mockLocalStorage();
+mockLocation();

--- a/src/tests/globals/mockLocation.ts
+++ b/src/tests/globals/mockLocation.ts
@@ -1,0 +1,17 @@
+const mockLocation = () => {
+  const oldWindowLocation = window.location;
+
+  // Disable a lint rule. This should be fine on the test
+  // and we've already redefine window.location below.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore The operand of a 'delete' operator must be optional
+  delete window.location;
+
+  Object.defineProperty(window, 'location', {
+    value: {
+      ...oldWindowLocation,
+    },
+  });
+};
+
+export default mockLocation;

--- a/src/tests/mockUserLoggedIn.ts
+++ b/src/tests/mockUserLoggedIn.ts
@@ -1,4 +1,4 @@
-import { LocalStorageKey } from 'hooks/useLocalStorage';
+import { LocalStorageKey } from 'lib/localStorage';
 import { Tokens, TokenType } from 'types/tokens';
 import { User } from 'types/user';
 


### PR DESCRIPTION
Closes https://github.com/rosle/react-nimble-survey/issues/31

## What happened 👀

- Intercepts the API response and logs the user out if the API returns 401 with `invalid_token`
- Small refactor on local storage to extract its logic to `lib` because I want to use it in the Axios interceptors.

## Insight 📝

Whenever we got 401 with `invalid_token`
  - Clears tokens and user from the local storage
  - Redirects the user to `/sign_in`

## Proof Of Work 📹

Right now there is no request so it's a bit hard to simulate this. So to trigger this, I clear out the user info from the local storage, put the expired token and then refresh the page, I should be redirected to the home page.

https://user-images.githubusercontent.com/6965195/192985872-662dbc6a-9c13-4dd7-9138-93ab3a2a228b.mov
